### PR TITLE
Hotfix/nest protect fixes

### DIFF
--- a/get_nest.sh
+++ b/get_nest.sh
@@ -94,13 +94,13 @@ do
       IDX=$(grep "^${TYPE} " nest_devices.cfg|awk '{print $NF}')
       if [ "${VALUE}" == "OK" ]
       then
-        VALUE="OK"
+        VALUE="0"
       elif [ "${VALUE}" == "WARNING" ]
       then
-        VALUE="WARNING"
+        VALUE="10"
       elif [ "${VALUE}" == "EMERGENCY" ]
       then
-        VALUE-"EMERGENCY"
+        VALUE="20"
       fi
 
       TYPE=SMOKSTAT
@@ -110,13 +110,13 @@ do
       IDX=$(grep "^${TYPE} " nest_devices.cfg|awk '{print $NF}')
       if [ "${VALUE}" == "OK" ]
       then
-        VALUE="OK"
+        VALUE="0"
       elif [ "${VALUE}" == "WARNING" ]
       then
-        VALUE="WARNING"
+        VALUE="10"
       elif [ "${VALUE}" == "EMERGENCY" ]
       then
-        VALUE-"EMERGENCY"
+        VALUE="20"
       fi
 
       TYPE=COSTAT

--- a/get_nest.sh
+++ b/get_nest.sh
@@ -146,7 +146,7 @@ do
     if [ "${TYPE}" == "SMOKSTAT" ]
     then
       print_action "Update ${TYPE} to $VALUE"
-      print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?    type=command&param=udevice&idx=${IDX}&nvalue=0&svalue=${VALUE}" 2>&1)"
+      print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?type=command&param=udevice&idx=${IDX}&nvalue=0&svalue=${VALUE}" 2>&1)"
 
       print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?type=command&param=addlogmessage&message=${IDX}|${TYPE}|${VALUE}&level=2" 2>&1)"
 

--- a/get_nest.sh
+++ b/get_nest.sh
@@ -39,8 +39,9 @@ TARGET_SET=0
 php get_nest.php| while read LINE
 do
   VALUE="$(echo ${LINE}|awk '{print $2}'|sed 's/,$//;s/\"//g')"
-  if [ ! -z "$(echo ${VALUE}|grep [0-9])" ]
-  then
+  
+  NUMERIC_REGEX='^[+-]?[0-9]+([.][0-9]+)?$'
+  if [[ $VALUE =~ $NUMERIC_REGEX ]] ; then
     VALUE="$(echo ${VALUE}|awk '{print sprintf("%.1f",$1)}')"
   fi
   case "$(echo ${LINE}|awk '{print $1}')" in

--- a/get_nest.sh
+++ b/get_nest.sh
@@ -44,7 +44,7 @@ do
     VALUE="$(echo ${VALUE}|awk '{print sprintf("%.1f",$1)}')"
   fi
   case "$(echo ${LINE}|awk '{print $1}')" in
-     ‘”device_id”:’)
+     '"device_id":')
      # added to address multiple Nest Protects
       DEVICE_ID=${VALUE}
      ;;
@@ -89,34 +89,34 @@ do
         VALUE="Off"
       fi
       ;;
-    ‘”smoke_status”:’)
+    '"smoke_status":')
       TYPE=SMOKSTAT_$DEVICE_ID
-      IDX=$(grep “^${TYPE} ” nest_devices.cfg|awk ‘{print $NF}’)
-      if [ “${VALUE}” == “OK” ]
+      IDX=$(grep "^${TYPE} " nest_devices.cfg|awk '{print $NF}')
+      if [ "${VALUE}" == "OK" ]
       then
-        VALUE=”OK”
-      elif [ “${VALUE}” == “WARNING” ]
+        VALUE="OK"
+      elif [ "${VALUE}" == "WARNING" ]
       then
-        VALUE=”WARNING”
-      elif [ “${VALUE}” == “EMERGENCY” ]
+        VALUE="WARNING"
+      elif [ "${VALUE}" == "EMERGENCY" ]
       then
-        VALUE-“EMERGENCY”
+        VALUE-"EMERGENCY"
       fi
 
       TYPE=SMOKSTAT
       ;;
-    ‘”co_status”:’)
+    '"co_status":')
       TYPE=COSTAT_$DEVICE_ID
-      IDX=$(grep “^${TYPE} ” nest_devices.cfg|awk ‘{print $NF}’)
-      if [ “${VALUE}” == “OK” ]
+      IDX=$(grep "^${TYPE} " nest_devices.cfg|awk '{print $NF}')
+      if [ "${VALUE}" == "OK" ]
       then
-        VALUE=”OK”
-      elif [ “${VALUE}” == “WARNING” ]
+        VALUE="OK"
+      elif [ "${VALUE}" == "WARNING" ]
       then
-        VALUE=”WARNING”
-      elif [ “${VALUE}” == “EMERGENCY” ]
+        VALUE="WARNING"
+      elif [ "${VALUE}" == "EMERGENCY" ]
       then
-        VALUE-“EMERGENCY”
+        VALUE-"EMERGENCY"
       fi
 
       TYPE=COSTAT
@@ -143,20 +143,20 @@ do
   print_debug "vars: TYPE:$TYPE VALUE:$VALUE IDX:$IDX"
   if [ ! -z "${IDX}" ]
   then
-    if [ “${TYPE}” == “SMOKSTAT” ]
+    if [ "${TYPE}" == "SMOKSTAT" ]
     then
-      print_action “Update ${TYPE} to $VALUE”
-      print_debug “$(curl -4 -X GET “http://${DOMOTICZ}/json.htm?    type=command&param=udevice&idx=${IDX}&nvalue=0&svalue=${VALUE}” 2>&1)”
+      print_action "Update ${TYPE} to $VALUE"
+      print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?    type=command&param=udevice&idx=${IDX}&nvalue=0&svalue=${VALUE}" 2>&1)"
 
-      print_debug “$(curl -4 -X GET “http://${DOMOTICZ}/json.htm?type=command&param=addlogmessage&message=${IDX}|${TYPE}|${VALUE}&level=2″ 2>&1)”
+      print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?type=command&param=addlogmessage&message=${IDX}|${TYPE}|${VALUE}&level=2" 2>&1)"
 
     fi
-    if [ “${TYPE}” == “COSTAT” ]
+    if [ "${TYPE}" == "COSTAT" ]
     then
-      print_action “Update ${TYPE} to $VALUE”
-      print_debug “$(curl -4 -X GET “http://${DOMOTICZ}/json.htm?type=command&param=udevice&idx=${IDX}&nvalue=0&svalue=${VALUE}” 2>&1)”
+      print_action "Update ${TYPE} to $VALUE"
+      print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?type=command&param=udevice&idx=${IDX}&nvalue=0&svalue=${VALUE}" 2>&1)"
 
-      print_debug “$(curl -4 -X GET “http://${DOMOTICZ}/json.htm?type=command&param=addlogmessage&message=${IDX}|${TYPE}|${VALUE}&level=2″ 2>&1)”
+      print_debug "$(curl -4 -X GET "http://${DOMOTICZ}/json.htm?type=command&param=addlogmessage&message=${IDX}|${TYPE}|${VALUE}&level=2" 2>&1)"
 
     fi
     if [ "${TYPE}" == "TEMP" ]


### PR DESCRIPTION
I was having some issues with the Nest Protect, mainly due to issues with quotes. And there was a line to determine if a value was numeric (at least that's what I suspected it would do), but this line only checked if there where numeric characters. If so, it would parse the whole value as a number. So my device id (for example: ABC123DEF456) would also be parsed to "0.0".

Please review this, because I only use the Nest Protect (and thus have only tested with Nest Protect) and my change may break other functionality.